### PR TITLE
Various fixes for the requests feature (2)

### DIFF
--- a/cogs/Request.py
+++ b/cogs/Request.py
@@ -323,6 +323,7 @@ class Request(commands.Cog):
             number_of_races="'Drop mid mogi': number of races played alone / 'Repick': number of races repicked",
             reason="Additional information you would like to give to the staff")
     async def append_penalty_slash(self, interaction: discord.Interaction, penalty_type: str, player_name: str, table_id: int, number_of_races: Optional[int], reason: Optional[str], leaderboard: Optional[str]):
+        await interaction.response.defer(ephemeral=True)
         ctx = await commands.Context.from_interaction(interaction)
         lb = get_leaderboard_slash(ctx, leaderboard)
         #if reason != None and not await check_against_automod_lists(ctx, reason):

--- a/cogs/Request.py
+++ b/cogs/Request.py
@@ -326,9 +326,6 @@ class Request(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         ctx = await commands.Context.from_interaction(interaction)
         lb = get_leaderboard_slash(ctx, leaderboard)
-        #if reason != None and not await check_against_automod_lists(ctx, reason):
-        #    await ctx.send("Your request was rejected because the \"reason\" field contains banned word(s)", ephemeral=True)
-        #    return
         if penalty_type not in penalty_static_info.keys():
             #Quick check in case discord autocomplete failed at forcing a particular value from the penalty choice list
             translation = CustomTranslator().translation_reverse_check(penalty_type)

--- a/util/AutoMod.py
+++ b/util/AutoMod.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
+from discord import AutoModRuleTriggerType
 
 import re
 
@@ -30,8 +31,15 @@ def create_pattern(word: str):
 
 #Return true is the word can be displayed by the bot
 async def check_against_automod_lists(ctx: commands.Context, message: str):
-    rules = await ctx.guild.fetch_automod_rules()
+    try:
+        rules = await ctx.guild.fetch_automod_rules()
+    except:
+        return True
     for rule in rules:
+        if rule.trigger.type != AutoModRuleTriggerType.keyword:
+            continue
+        if len(rule.trigger.keyword_filter) == 0:
+            continue
         long_word_pattern = []
         short_word_pattern = []
         for word in rule.trigger.keyword_filter:


### PR DESCRIPTION
- Adapt FFA name violation check to adjust to the rules
- Add defer to the request command
- Remove automod check until I found what cause the issue
- Force reporter to commit on both a multiplier and a strike when requesting a drop penalty (prevent cases where they would request a penalty, wait for the tab to be updated and remove the request just after)
- Also add a multiplier if a "drop before start" penalty is issued with a number of races (To account for cases where someone drop before start but no sub is found and the mogi starts anyway, it's probably a SQ only issue)