### PR TITLE
Add name request command/button/modal

### DIFF
--- a/cogs/Names.py
+++ b/cogs/Names.py
@@ -1,13 +1,27 @@
+import re
 import discord
-from discord import app_commands
+from discord import app_commands, User, Member
 from discord.ext import commands
-from custom_checks import check_name_restricted_roles, check_valid_name, yes_no_check, app_command_check_staff_roles, command_check_staff_roles
+from discord.utils import format_dt
+from custom_checks import (
+  check_name_restricted_roles,
+  check_valid_name,
+  yes_no_check,
+  app_command_check_staff_roles,
+  command_check_staff_roles,
+  app_command_check_admin_roles,
+  app_command_check_name_restricted_roles
+)
 import custom_checks
-from models import LeaderboardConfig
+from models import LeaderboardConfig, PlayerDetailed, UpdatingBot
 import API.get, API.post
 from datetime import datetime, timedelta, timezone
 from util import get_leaderboard, get_leaderboard_slash
 from typing import Optional
+
+NAME_MIN_LENGTH = 2
+NAME_MAX_LENGTH = 16
+DAYS_BETWEEN_NAME_CHANGES = 60
 
 class Names(commands.Cog):
     def __init__(self, bot):
@@ -309,6 +323,201 @@ class Names(commands.Cog):
         ctx = await commands.Context.from_interaction(interaction)
         lb = get_leaderboard_slash(ctx, leaderboard)
         await self.update_player_name(ctx, lb, old_name, new_name)
+
+    @name_group.command(name="request_message")
+    @app_commands.check(app_command_check_admin_roles)
+    @app_commands.autocomplete(leaderboard=custom_checks.leaderboard_autocomplete)
+    async def create_name_request(
+        self, interaction: discord.Interaction, leaderboard: Optional[str]):
+        """Creates the name request button."""
+        ctx = await commands.Context.from_interaction(interaction)
+        lb = get_leaderboard_slash(ctx, leaderboard)
+        if ctx.channel.id != lb.name_request_channel:
+            await ctx.send(
+                f"You may only use this command in <#{lb.name_request_channel}>"
+            )
+            return
+
+        embed = discord.Embed(
+            title="Name Change Request",
+            description="Please read the guidelines before making a request."
+        )
+
+        await ctx.send(embed=embed, view=NameRequestButton(lb))
+
+class NameRequestModal(discord.ui.Modal, title="Name Change Request"):
+    """Name change request modal class"""
+    def __init__(self, player: PlayerDetailed, lb: LeaderboardConfig):
+        super().__init__()
+        self.player = player
+        self.lb = lb
+
+    name = discord.ui.TextInput(
+      label="Username",
+      required=True,
+      min_length=NAME_MIN_LENGTH,
+      max_length=NAME_MAX_LENGTH,
+      style=discord.TextStyle.short
+    )
+
+    async def on_submit(self, interaction: discord.Interaction):
+        """Validates the request and returns a response"""
+        name = self.name.value.strip()
+
+        name_valid, error = self.validate_requested_name(name)
+
+        if not name_valid:
+            await interaction.response.send_message(error, ephemeral=True)
+            return
+
+        success, request = await API.post.requestNameChange(
+            self.lb.website_credentials,
+            self.player.name,
+            name
+        )
+
+        if success is False:
+            await interaction.response.send_message(
+                f"An error occurred trying to request a name:\n{request}",
+                ephemeral=True
+            )
+            return
+
+        message = (
+            "Your name change request has been sent to staff for approval. "
+            "Please wait, you will receive a DM when this request is accepted "
+            "or denied (if you have server member DMs enabled)."
+        )
+
+        await interaction.response.send_message(
+            message,
+            ephemeral=True
+        )
+        guild = interaction.guild
+        if not guild:
+            return
+
+        log_channel = guild.get_channel(self.lb.name_request_log_channel)
+        if log_channel:
+            assert isinstance(log_channel, discord.TextChannel)
+            embed = discord.Embed(title="New Name Change Request")
+            embed.add_field(name="Current Name", value=self.player.name, inline=False)
+            embed.add_field(name="New Name", value=name, inline=False)
+            log_msg = await log_channel.send(embed=embed)
+            await API.post.setNameChangeMessageId(
+                self.lb.website_credentials,
+                self.player.name,
+                log_msg.id
+            )
+
+    def validate_requested_name(self, name: str):
+        """Validates the requested name"""
+
+        validations = {
+            f"Your name is fewer than {NAME_MIN_LENGTH} characters.": lambda s: len(s) >= 
+            NAME_MIN_LENGTH,
+            f"Your name is longer than {NAME_MAX_LENGTH} characters": lambda s: len(s) <= 
+            NAME_MAX_LENGTH,
+            "Your name contains an invalid character.": lambda s: bool(
+                re.fullmatch(r'^[a-zA-Z0-9\-_. ]*$', s)
+            ),
+            "Your name does not contain at least one letter.": lambda s: bool(
+                re.search(r'[a-zA-Z]', s)
+            )
+        }
+
+        for error, validation in validations.items():
+            if not validation(name):
+                return (False, error)
+
+        return (True, None)
+
+class NameRequestButton(discord.ui.View):
+    """Name Request Button"""
+    def __init__(self, lb: LeaderboardConfig):
+        super().__init__(timeout=None)
+        self.lb = lb
+
+    @discord.ui.button(label="Request")
+    async def name_request_button(
+        self, interaction: discord.Interaction[UpdatingBot], _: discord.ui.Button):
+        """Button click handler"""
+
+        player = await API.get.getPlayerDetailsFromDiscord(
+            self.lb.website_credentials, interaction.user.id
+        ) # type: ignore
+
+        can_request, error_message = await self.validate_name_button_request(
+            interaction,
+            interaction.user,
+            player
+        )
+
+        if not can_request:
+            await interaction.response.send_message(error_message, ephemeral=True)
+            return
+
+        assert player
+        await interaction.response.send_modal(NameRequestModal(player, self.lb))
+
+    async def validate_name_button_request(
+        self, interaction: discord.Interaction[UpdatingBot],
+        user: User | Member, player: PlayerDetailed | None) -> tuple[bool, str | None]:
+        """Validates whether the user is able to request a name"""
+        validations = {
+            (
+                "Name Restricted players cannot request a new nickname"
+            ): lambda _, __: not app_command_check_name_restricted_roles(interaction),
+            (
+                "Your Discord ID is not linked to a Lounge profile. "
+                "Please open a support ticket"
+            ): lambda _, plyr: plyr
+            is not None,
+            (
+                "Last changed name at {LAST_NAME_CHANGE}. "
+                "You can request a new name "
+                "on {NEXT_NAME_CHANGE}"
+            ): lambda _, plyr: self.eligible_for_name_change(plyr),
+        }
+
+        for error, validation in validations.items():
+            if not validation(user, player):
+                message_context = self.get_message_context(player)
+                return (False, error.format(**message_context))
+
+        return (True, None)
+
+    def get_message_context(self, player: PlayerDetailed | None) -> dict[str, str]:
+        """Returns message context"""
+        msg_context = {}
+        if player is None:
+            return msg_context
+
+        last_name_change_date = player.name_history[0].changed_on
+
+        msg_context.update({
+            "LAST_NAME_CHANGE": format_dt(last_name_change_date, "d"),
+            "NEXT_NAME_CHANGE": format_dt(
+                last_name_change_date + timedelta(days=DAYS_BETWEEN_NAME_CHANGES),
+                "d"
+            )
+        })
+        return msg_context
+
+    def eligible_for_name_change(self, player: PlayerDetailed | None) -> bool:
+        """
+        Returns a boolean if the days elapsed since a player's
+        last name change exceeds the permitted days between changes
+        """
+        if player is None:
+            return False
+
+        last_name_change_date = player.name_history[0].changed_on
+        days_since_last_change = (datetime.now(timezone.utc) - last_name_change_date).days
+        if days_since_last_change < DAYS_BETWEEN_NAME_CHANGES:
+            return False
+
+        return True
 
 async def setup(bot):
     await bot.add_cog(Names(bot))

--- a/custom_checks.py
+++ b/custom_checks.py
@@ -51,7 +51,18 @@ def check_name_restricted_roles(ctx, member):
         return False
     check_roles = (server_info.name_restricted_roles)
     return check_role_list(member, check_roles)
-    
+
+def app_command_check_name_restricted_roles(interaction: discord.Interaction[UpdatingBot]):
+    """App command version of check_name_restricted_roles"""
+    if interaction.guild is None:
+        raise GuildNotFoundException
+    server_info: ServerConfig | None = interaction.client.config.servers.get(
+        interaction.guild.id, None)
+    if not server_info:
+        raise GuildNotFoundException
+    check_roles = server_info.name_restricted_roles
+    return check_role_list(interaction.user, (check_roles))
+
 # command version of check_reporter_roles; throws error if false
 def command_check_reporter_roles(ctx):
     server_info: ServerConfig = ctx.bot.config.servers.get(ctx.guild.id, None)


### PR DESCRIPTION
Uses the button and modal components from Discord to make a new way of making name requests. The motivations behind these changes are:
- To remove the nickname guidelines away from the official Lounge ruleset.
- To promptly remind users of the nickname guidelines before a request is made.
- To make it easier to understand for new users to change their name

## Features
- A command to generate the embed & button to request a name.
  - This currently is an admin-only command.
  - The command can currently only be used in the specified name change request channel.
- Messages the user ephemerally if not qualified to request a new name.
  - i.e. name restricted, Discord ID not connected, recent name change.
- Displays a modal to submit the new nickname with character limit.
- Additional validation to check against the guidelines before the requested name is submitted.

  > Acknowledge that naming guidelines are different across the servers they operate in as these aren't restrictions applied by the Lounge-API. If such checks are disruptive then they can be removed.
- Ephemeral reply to the user of processed request. The rest of the name change process remains unchanged.
- Extra command in `custom_checks.py` to check for the name restricted role via an interaction.

Existing commands have not been edited or removed.

## Example implementation
### Guidelines & Button
![image](https://github.com/user-attachments/assets/259e0215-5581-49a0-8d67-6aba74301d59)
### Button responses
![image](https://github.com/user-attachments/assets/fe24f7ec-8459-4a8a-a709-fff0c272b6a4)
![image](https://github.com/user-attachments/assets/34b50ad0-36c5-4690-889b-af3b7564bccb)

### Modal
![image](https://github.com/user-attachments/assets/8c657f4c-ffa4-42fc-a1e2-24add91b553a)
### Modal responses
![image](https://github.com/user-attachments/assets/c182b993-1f88-4e7f-afb4-2f4cf23ada82)
![image](https://github.com/user-attachments/assets/d5ed93d3-3116-447a-a673-8bfdf25ba7c1)
![image](https://github.com/user-attachments/assets/fd430659-bff0-4ef1-9832-9b132b8495fa)

