### PR TITLE
Penalty data for requests in config file

### DIFF
--- a/cogs/Requests.py
+++ b/cogs/Requests.py
@@ -136,9 +136,10 @@ class DropInstance(PenaltyInstance):
         ctx.prefix = prefix_copy
             
 def penalty_instance_builder(penalty_name, type, lounge_id, table_id, number_of_races = 0):
-    if type == 1:
+    #Check over all types from PenaltyType in Config.py
+    if type.value == "Drop":
         return DropInstance(penalty_name, lounge_id, table_id, number_of_races)
-    if type == 2:
+    if type.value == "Repick":
         return RepickInstance(penalty_name, lounge_id, table_id, number_of_races)
     else:
         return PenaltyInstance(penalty_name, lounge_id, table_id)

--- a/models/Config.py
+++ b/models/Config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 
 @dataclass
 class WebsiteCredentials:
@@ -27,9 +28,14 @@ class PlayerCountSettings:
     valid_formats: list[int]
     place_scores: dict[int, int]
 
+class PenaltyType(str, Enum):
+    Basic = "Basic"
+    Drop = "Drop"
+    Repick = "Repick"
+
 @dataclass
-class PenaltyTypes:
-    type: int
+class PenaltyConfig:
+    type: PenaltyType
     amount: int
     is_strike: bool
 
@@ -47,7 +53,7 @@ class LeaderboardConfig:
     mute_ban_list_channel: int
     quick_start_channel: int
     player_settings: dict[int, PlayerCountSettings]
-    penalty_types: dict[str, PenaltyTypes]
+    penalty_types: dict[str, PenaltyConfig]
     races_per_mogi: int
     gps_per_mogi: int
     enable_verification_dms: bool

--- a/models/Config.py
+++ b/models/Config.py
@@ -28,6 +28,12 @@ class PlayerCountSettings:
     place_scores: dict[int, int]
 
 @dataclass
+class PenaltyTypes:
+    type: int
+    amount: int
+    is_strike: bool
+
+@dataclass
 class LeaderboardConfig:
     name: str
     website_credentials: WebsiteCredentials
@@ -41,6 +47,7 @@ class LeaderboardConfig:
     mute_ban_list_channel: int
     quick_start_channel: int
     player_settings: dict[int, PlayerCountSettings]
+    penalty_types: dict[str, PenaltyTypes]
     races_per_mogi: int
     gps_per_mogi: int
     enable_verification_dms: bool


### PR DESCRIPTION
**Modifications:**

- Config file contains a dict for static penalty data per leaderboard. (penalty_name: type, amount, is_strike)

**To be aware of:**

- In case of mismatch between names of requests in DB, it needs to be deleted with the /refuse_penalty (if possible, resolve all requests before modifying penalty data names in config file)
- Due to some constraints, for a same server with multiple leaderboards, all penalty types from all the server leaderboards will be displayed in the choice list with the /request_penalty command. But it won't be possible to go further than that with a name in a leaderboard that doesn't contains it. It "might" confuse people but other than that it should be safe.
- Possibility to create more easily penalty types with specific behaviour. You need to create a penalty type class that overrides the necessary functions, Add an entry in the PenaltyType enum in Config.py, add this entry in the penalty_instance_builder function, use this entry in the config file.
- When modifying penalty names in the config file, please also consider adding an entry in the dict of the translation class for new penalty names.