### PR TITLE
Display penalty ID when showing the penalty history

### DIFF
--- a/cogs/Penalties.py
+++ b/cogs/Penalties.py
@@ -50,7 +50,7 @@ class Penalties(commands.Cog):
                 strike_str += "----------\n"
             date_formatted = discord.utils.format_dt(strike.awarded_on, style="d")
             date_relative = discord.utils.format_dt(strike.awarded_on, "R")
-            strike_str += f"{date_formatted} ({date_relative})\n"
+            strike_str += f"ID: {strike.id} {date_formatted} ({date_relative})\n"
         return strike_str
 
     async def pen_channel(self, ctx: commands.Context, lb: LeaderboardConfig, player: Player, tier: str, reason: str | None, table_id: int | None,


### PR DESCRIPTION
Add the penalty ID each time we are showing the penalty history to simplify the search of past strikes.

This makes it appear with the strikelist command and in the embbed when we are giving a strike. With the latter the last given penalty ID appears twice in the embbed but that's not that much of an issue.

This may not be an essential change but I saw some staff arguing that it could be an interesting thing to have and I mostly agree with it.