### PR TITLE
Force players to input a number of races for drop and repick penalty requests + others modif

### DIFF
--- a/cogs/Requests.py
+++ b/cogs/Requests.py
@@ -328,6 +328,9 @@ class Requests(commands.Cog):
                 await ctx.send("You need to be on the tab to ask for a penalty", ephemeral=True)
                 return
         if reason == None:
+            if penalty_type == "Host issues":
+                await ctx.send("You need to explain the situation in the \"reason\" field for us to review this penalty type")
+                return
             reason = ""
         if penalty_type == "3+ dcs" and (number_of_races == None or number_of_races < 3):
             await ctx.send("Please enter the exact number of races mate(s) of the reported player played alone in \"number_of_races\".", ephemeral=True)

--- a/cogs/Requests.py
+++ b/cogs/Requests.py
@@ -58,7 +58,7 @@ class RepickInstance(PenaltyInstance):
 
     def create_embed(self, ctx, request_id, player_name, reason):
         partial_embed = PenaltyInstance.create_embed(self, ctx, request_id, player_name, reason)
-        partial_embed.add_field(name="Number of invalid races picked", value=self.total_repick)
+        partial_embed.add_field(name="Number of invalid races picked and played", value=self.total_repick)
         return partial_embed
 
     async def apply_penalty(self, lb, ctx, penalties_cog, tier, player_name, amount, is_strike):


### PR DESCRIPTION
- Always display the number of races for drop and repick even if its value is 0
- The number_of_races value is optional but it is required for a user to fill it in case a "Drop" or "Repick" penalty type is chosen (There is still a special case for "3+ dcs" where we are waiting for a value of at least 3)

New recent commits:
- Reword a string from repick penalty to avoid ambiguity (picked and not played vs picked and actually played)
- Force players to give a reason for the "host issues" penalty in order to help updaters validate this kind of penalties
