### PR TITLE
Change minimum value from 1 to 0 for /penalty strike

### DIFF
--- a/cogs/Penalties.py
+++ b/cogs/Penalties.py
@@ -170,7 +170,7 @@ class Penalties(commands.Cog):
     @penalty_group.command(name="strike")
     @app_commands.check(app_command_check_updater_roles)
     @app_commands.autocomplete(leaderboard=custom_checks.leaderboard_autocomplete)
-    async def strike_slash(self, interaction: discord.Interaction, amount:app_commands.Range[int, 1, 200], tier:str, names: str, 
+    async def strike_slash(self, interaction: discord.Interaction, amount:app_commands.Range[int, 0, 200], tier:str, names: str, 
                                 reason:str | None, leaderboard: Optional[str], anonymous: bool = False):
         ctx = await commands.Context.from_interaction(interaction)
         lb = get_leaderboard_slash(ctx, leaderboard)


### PR DESCRIPTION
Change minimum value from 1 to 0 MMR for "/penalty strike" to allow for strike without 0 MMR penalty with the slash command.

It makes only sense for the "/penalty strike" and not for the "/penalty new" where we want to at least modify the MMR

Note: I wasn't able to test it locally, for some reason the range was stuck with the original value (probably some kind of unsynced or cached value from discord, but worth mentioning)